### PR TITLE
Fix for possible DNS lookup failure during wget command.

### DIFF
--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -54,12 +54,12 @@ function default_settings() {
 function update_script() {
 header_info
 if [[ ! -d /opt/AdGuardHome ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+wget -qL https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz
 msg_info "Stopping AdguardHome"
 systemctl stop AdGuardHome
 msg_ok "Stopped AdguardHome"
 
 msg_info "Updating AdguardHome"
-wget -qL https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz
 tar -xvf AdGuardHome_linux_amd64.tar.gz &>/dev/null
 mkdir -p adguard-backup
 cp -r /opt/AdGuardHome/AdGuardHome.yaml /opt/AdGuardHome/data adguard-backup/
@@ -74,7 +74,7 @@ msg_ok "Started AdguardHome"
 msg_info "Cleaning Up"
 rm -rf AdGuardHome_linux_amd64.tar.gz AdGuardHome adguard-backup
 msg_ok "Cleaned"
-msg_ok "Update Successfull"
+msg_ok "Update Successful"
 exit
 }
 


### PR DESCRIPTION


## I wanted to make you aware that I am meticulous when it comes to merging code into the main branch, so please don't take it personally if I reject your request.

## Description

This simply downloads the newest Adguard files before shutting down Adguard itself; this resolves the issue of Adguard no longer being available to query in order for DNS to respond with the proper address.

Fixes https://github.com/tteck/Proxmox/issues/1121

## Type of change

Please delete options that are not relevant.

- [X] Bug fix 
